### PR TITLE
Fetch items by id, including children comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@
 Attempts to incorporate `webpack` have failed. Consider reviewing the commit history to see the various configurations that did not work. Simple functions operated without issue, but functions with Firebase functionality fail. The issue appeared to be caused by async/await functionality, but Promises in general had issues.
 
 At some point in the future, `dom` should be removed as a library. Additionally, `webpack` should be included. `webpack` is important due to its ability to reduce bundle sizes and streamline code generation. The bundle size without webpack is ~16MB for ANY function. With webpack, the `hello` function drops to ~3KB while hn-api drops to ~350KB.
+
+## Future Reference
+Do not use `console.dir()` with AWS. The logs are difficult to decipher (line breaks prevent useful grouping).

--- a/data/api-request-event-real.json
+++ b/data/api-request-event-real.json
@@ -1,0 +1,43 @@
+{
+  "resource:": "/api/v1/item/{id}",
+  "path:": "/api/v1/item/12345",
+  "httpMethod:": "GET",
+  "headers:": null,
+  "multiValueHeaders:": null,
+  "queryStringParameters:": null,
+  "multiValueQueryStringParameters:": null,
+  "pathParameters:": {
+    "id:": "12345"
+  },
+  "stageVariables:": null,
+  "requestContext:": {
+    "path:": "/api/v1/item/{id}",
+    "accountId:": "729037857495",
+    "resourceId:": "zuwcux",
+    "stage:": "test-invoke-stage",
+    "domainPrefix:": "testPrefix",
+    "requestId:": "10891e3b-1c4a-11e9-8662-67f5384b099c",
+    "identity:": {
+      "cognitoIdentityPoolId:": null,
+      "cognitoIdentityId:": null,
+      "apiKey:": "test-invoke-api-key",
+      "cognitoAuthenticationType:": null,
+      "userArn:": "arn:aws:sts::729037857495:assumed-role/OrganizationAccountAccessRole/chandler",
+      "apiKeyId:": "test-invoke-api-key-id",
+      "userAgent:": "aws-internal/3 aws-sdk-java/1.11.465 Linux/4.9.137-0.1.ac.218.74.329.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.192-b12 java/1.8.0_192",
+      "accountId:": "729037857495",
+      "caller:": "AROAJFXXJ5BJW7Q32FK52:chandler",
+      "sourceIp:": "test-invoke-source-ip",
+      "accessKey:": "ASIA2TPQK4LLZJDJIRUX",
+      "cognitoAuthenticationProvider:": null,
+      "user:": "AROAJFXXJ5BJW7Q32FK52:chandler"
+    },
+    "domainName:": "testPrefix.testDomainName",
+    "resourcePath:": "/api/v1/item/{id}",
+    "httpMethod:": "GET",
+    "extendedRequestId:": "Txr6qE39PHcF7Fw=",
+    "apiId:": "jo0norcal4"
+  },
+  "body:": null,
+  "isBase64Encoded:": false
+}

--- a/data/api-request-event.json
+++ b/data/api-request-event.json
@@ -1,0 +1,62 @@
+{
+  "body": "eyJ0ZXN0IjoiYm9keSJ9",
+  "resource": "/{proxy+}",
+  "path": "/path/to/resource",
+  "httpMethod": "POST",
+  "isBase64Encoded": true,
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-west-2.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/data/api-request-event.json
+++ b/data/api-request-event.json
@@ -8,7 +8,8 @@
     "foo": "bar"
   },
   "pathParameters": {
-    "proxy": "/path/to/resource"
+    "proxy": "/path/to/resource",
+    "id": "8863"
   },
   "stageVariables": {
     "baz": "qux"

--- a/package-lock.json
+++ b/package-lock.json
@@ -543,6 +543,44 @@
       "integrity": "sha512-Pbeh0i6OLubPJdIdCepn8ZQHwN2MWznZHbHABSTEfQ706ie+yuxNSaPdqX1xRatT6WanaS1EazMiSg0NUW2XxQ==",
       "dev": true
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -786,6 +824,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "bytebuffer": {
@@ -1445,6 +1489,12 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "dom-storage": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
@@ -1557,6 +1607,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
@@ -3044,6 +3100,12 @@
       "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
@@ -3729,6 +3791,12 @@
         "superagent": "^3.8.3"
       }
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -4003,6 +4071,15 @@
       "resolved": "https://registry.npmjs.org/replaceall/-/replaceall-0.1.6.tgz",
       "integrity": "sha1-gdgax663LX9cSUKt8ml6MiBojY4=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+      "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -4817,6 +4894,41 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
+      }
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "description": "Serverless webpack example using Typescript",
   "scripts": {
+    "lint": "tslint --project .",
     "compile": "tsc",
+    "build": "npm run lint && npm run compile",
     "compile:watch": "npm run compile -- --watch",
-    "predeploy:dev": "npm run compile",
+    "predeploy:dev": "npm run build",
     "deploy:dev": "serverless deploy --stage dev",
     "preoffline": "npm run compile",
     "offline": "serverless offline",
@@ -21,6 +23,7 @@
     "serverless": "^1.36.1",
     "serverless-offline": "^4.1.4",
     "source-map-support": "^0.5.6",
+    "tslint": "^5.12.1",
     "typescript": "^3.2.4"
   },
   "author": "Chandler Wall",

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,10 +18,10 @@ functions:
     events:
       - http:
           method: get
-          path: hello
+          path: api/v1/meta/health
   hn-api:
     handler: dist/hn-api.hn
     events:
       - http:
           method: get
-          path: hn
+          path: api/v1/item/{id}

--- a/src/hello.ts
+++ b/src/hello.ts
@@ -1,12 +1,13 @@
 import {APIGatewayProxyHandler} from "aws-lambda";
 
 export const hello: APIGatewayProxyHandler = async (event, context) => {
+  // TODO - This function needs to be come a health check.
   return {
     statusCode: 200,
     body: JSON.stringify({
       message: "Go Serverless Webpack (Typescript) v1.0! Your function executed successfully!",
       input: event,
-      context: context,
+      context,
     }),
   };
 };

--- a/src/hn-api.ts
+++ b/src/hn-api.ts
@@ -12,7 +12,7 @@ export async function hn(event: APIGatewayProxyEvent): Promise<APIGatewayProxyRe
   let id;
   // TODO - Create helper/wrapper method to simplify try-catch interactions.
   try {
-    id = event.pathParameters["id"];
+    id = event.pathParameters.id;
 
     // TODO - Include helper method to validate path parameters.
     if (id == null) {

--- a/src/hn-api.ts
+++ b/src/hn-api.ts
@@ -1,23 +1,27 @@
-import {APIGatewayProxyResult} from "aws-lambda";
+import {APIGatewayProxyEvent, APIGatewayProxyResult} from "aws-lambda";
 import firebase from "firebase/app";
 import "firebase/database";
 import App = firebase.app.App;
+import Database = firebase.database.Database;
 import DataSnapshot = firebase.database.DataSnapshot;
-import Reference = firebase.database.Reference;
 
 const API_URL = "https://hacker-news.firebaseio.com";
 const API_VERSION = "/v0";
 
-export async function hn(): Promise<APIGatewayProxyResult> {
+export async function hn(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+  console.log(event);
+
+  const id = event.pathParameters["id"];
+
   let app: App;
   let data: any;
 
   try {
     // TODO - Look for an existing Firebase application before creating a new one.
     app = firebase.initializeApp({databaseURL: API_URL});
-    const db: Reference = app.database().ref(API_VERSION);
-    const path = "item/192327";
-    const item = db.child(path);
+    const db: Database = app.database();
+    const path = `item/${id}`;
+    const item = db.ref(API_VERSION).child(path);
     const snapshot: DataSnapshot = await item.once("value");
     data = snapshot.val();
   } catch (error) {
@@ -31,6 +35,7 @@ export async function hn(): Promise<APIGatewayProxyResult> {
 
   return {
     statusCode: 200,
+    headers: {},
     body: JSON.stringify(data),
   };
 }

--- a/src/hn-api.ts
+++ b/src/hn-api.ts
@@ -9,9 +9,37 @@ const API_URL = "https://hacker-news.firebaseio.com";
 const API_VERSION = "/v0";
 
 export async function hn(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
-  console.log(event);
+  let id;
+  // TODO - Create helper/wrapper method to simplify try-catch interactions.
+  try {
+    id = event.pathParameters["id"];
 
-  const id = event.pathParameters["id"];
+    // TODO - Include helper method to validate path parameters.
+    if (id == null) {
+      console.error("Missing path parameter: id");
+
+      // TODO - Create helper method to return consistent responses for various scenarios.
+      return {
+        statusCode: 400,
+        headers: {},
+        body: JSON.stringify({
+          status: "Error",
+          message: "Missing path parameter: id",
+        }),
+      };
+    }
+  } catch (error) {
+    console.error(error);
+    // TODO - Create helper method to return consistent responses for various scenarios.
+    return {
+      statusCode: 400,
+      headers: {},
+      body: JSON.stringify({
+        status: "Error",
+        message: "Unknown error processing path parameters.",
+      }),
+    };
+  }
 
   let app: App;
   let data: any;
@@ -23,6 +51,7 @@ export async function hn(event: APIGatewayProxyEvent): Promise<APIGatewayProxyRe
     const path = `item/${id}`;
     const item = db.ref(API_VERSION).child(path);
     const snapshot: DataSnapshot = await item.once("value");
+    // TODO - Check if the requested reference exists. Return 404 if the requested item does not exist.
     data = snapshot.val();
   } catch (error) {
     console.error(error);

--- a/src/hn-api.ts
+++ b/src/hn-api.ts
@@ -76,9 +76,10 @@ async function fetchItemById(firebaseApp: App, id: any) {
   console.log(`Finish fetching ${id}`);
 
   let comments: object[] = [];
-  if (item.kids && item.kids.length) {
+  if (item && item.kids && item.kids.length) {
     comments = await Promise.all(item.kids.map((kid: any) => {
       console.log(`Prepare to fetch kid ${kid}`);
+      // TODO - Is there a better way than recursion?
       const kidItem = fetchItemById(firebaseApp, kid);
       console.log(`Finish fetching kid ${kid}`);
       return kidItem;

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,14 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended"
+  ],
+  "jsRules": {},
+  "rules": {
+    "no-console": {
+      "severity": "warning"
+    },
+    "object-literal-sort-keys": false
+  },
+  "rulesDirectory": []
+}


### PR DESCRIPTION
#### Description
The changes in this PR are needed to support path-based item fetching by `id`. An item can be requested for a specific `id`. As the item is fetched, any children/kids are also fetched and included.

#### Notes
The current implementation for comment (`kids`) fetching is unbounded recursion. This may need to be improved in the future.

This PR also includes `tslint` and additional nom scripts.